### PR TITLE
Fix spelling errors in documentation comments

### DIFF
--- a/lib/conditional.js
+++ b/lib/conditional.js
@@ -8,7 +8,7 @@ const once = require('once');
  *
  * @param {(boolean|function)} condition
  *   If true, the middleware will be executed, else the next middleware will be
- *   executed. If the conddition is a function it will be executed with the req,
+ *   executed. If the condition is a function it will be executed with the req,
  *   res, and next arguments. The return of the function will be used as the
  *   conditional.
  * @param {function} success
@@ -17,7 +17,7 @@ const once = require('once');
  *   The middleware to conditionally execute if condition is false.
  *
  * @return {function}
- *   A middleware wraper to conditionally execute another middleware.
+ *   A middleware wrapper to conditionally execute another middleware.
  *
  * @example
  *   // Will enable middleware for requests that use the application/json accept


### PR DESCRIPTION
I noticed these two spelling errors in documentation comments and fixed them.